### PR TITLE
Day 7 solution

### DIFF
--- a/2022/solutions/day7.clj
+++ b/2022/solutions/day7.clj
@@ -63,9 +63,9 @@ $ ls
 (as-> sample-input $
   (string/split-lines $)
   (reduce run-cmd ;; Builds directory structure as vector tree
-          (z/zipper #(contains? % :children) :children #(assoc %1 :children %2) [{:path "/" :size 0 :children []}])
+          (z/zipper #(contains? % :children) :children #(assoc %1 :children %2) {:path "/" :size 0 :children []})
           (drop 1 $))
-  (z/root $)
+  (z/up $)
   #_(z/root $) ;; return to root of tree
   #_(z/node $)
   #_(iterate z/next $)

--- a/2022/solutions/day7.clj
+++ b/2022/solutions/day7.clj
@@ -30,9 +30,9 @@ $ ls
 (def input (slurp "input/day7.txt"))
 
 (defn read-file-description
-    [line]
+    [line] 
     (let [[size filename] (string/split line #" ")]
-        [filename (read-string size)]))
+        {:path filename :size (read-string size)}))
 
 (defn go-to-child
   "Returns the zipper at the child node's location."
@@ -41,7 +41,7 @@ $ ls
        z/down
        (iterate z/right)
        (drop-while #(or (not (z/branch? %))
-                        (not= (-> % z/node first) child)))
+                        (not= (-> % z/node :path) child)))
        first))
 
 (defn run-cmd [zp line]
@@ -52,26 +52,29 @@ $ ls
         (go-to-child zp (string/replace line "$ cd " ""))
 
         (string/starts-with? line "dir ")
-        (z/append-child zp [(string/replace line "dir " "") 0])
+        (z/append-child zp {:path (string/replace line "dir " "") :size 0 :children []})
 
         (re-matches #"^\d+\s.*" line)
         (z/append-child zp (read-file-description line))
-
+        
         :else zp))
 
 
 (as-> sample-input $
   (string/split-lines $)
   (reduce run-cmd ;; Builds directory structure as vector tree
-          (z/vector-zip ["/" 0])
+          (z/zipper #(contains? % :children) :children #(assoc %1 :children %2) [{:path "/" :size 0 :children []}])
           (drop 1 $))
-  (z/root $) ;; return to root of tree
-  (dir-size $)
-  #_(drop-while z/branch? $)
+  (z/root $)
+  #_(z/root $) ;; return to root of tree
+  #_(z/node $)
+  #_(iterate z/next $)
+  #_(take 2 $)
+  #_(take-while (comp not z/end?) $)
   #_(reduce (fn [acc line] ;; Here we calculate and collect directory sizes
-            (z/next))
-          {:zp $ :size 0}
-          $))
+              (z/next))
+            {:zp $ :sizeize 0}
+            $))
 
 
 (comment

--- a/2022/solutions/day7.clj
+++ b/2022/solutions/day7.clj
@@ -1,0 +1,94 @@
+(ns day7
+  (:require [clojure.string :as string]
+            [clojure.zip :as z]))
+
+(def sample-input
+  "$ cd /
+$ ls
+dir a
+14848514 b.txt
+8504156 c.dat
+dir d
+$ cd a
+$ ls
+dir e
+29116 f
+2557 g
+62596 h.lst
+$ cd e
+$ ls
+584 i
+$ cd ..
+$ cd ..
+$ cd d
+$ ls
+4060174 j
+8033020 d.log
+5626152 d.ext
+7214296 k")
+
+(def input (slurp "input/day7.txt"))
+
+(defn read-file-description
+    [line]
+    (let [[size filename] (string/split line #" ")]
+        [filename (read-string size)]))
+
+(defn go-to-child
+  "Returns the zipper at the child node's location."
+  [zipper child]
+  (->> zipper
+       z/down
+       (iterate z/right)
+       (drop-while #(or (not (z/branch? %))
+                        (not= (-> % z/node first) child)))
+       first))
+
+(defn run-cmd [zp line]
+  (cond (= line "$ cd ..")
+        (z/up zp)
+
+        (string/starts-with? line "$ cd ")
+        (go-to-child zp (string/replace line "$ cd " ""))
+
+        (string/starts-with? line "dir ")
+        (z/append-child zp [(string/replace line "dir " "") 0])
+
+        (re-matches #"^\d+\s.*" line)
+        (z/append-child zp (read-file-description line))
+
+        :else zp))
+
+
+(as-> sample-input $
+  (string/split-lines $)
+  (reduce run-cmd ;; Builds directory structure as vector tree
+          (z/vector-zip ["/" 0])
+          (drop 1 $))
+  (z/root $) ;; return to root of tree
+  (dir-size $)
+  #_(drop-while z/branch? $)
+  #_(reduce (fn [acc line] ;; Here we calculate and collect directory sizes
+            (z/next))
+          {:zp $ :size 0}
+          $))
+
+
+(comment
+  fs
+  (as-> zp zp
+    (z/append-child zp ["a" []])
+    (z/append-child zp ["b.txt" 14848514])
+    (z/append-child zp ["c.dat" 8504156])
+    (z/append-child zp ["d" []])
+    (go-to-child zp "d")
+    (z/node zp))
+
+  #_(z/append-child zp ["e"])
+  #_(z/append-child zp ["f" 29116])
+  #_(z/append-child zp ["g" 2557])
+  #_(z/append-child zp ["h.lst" 62596])
+  #_(z/up zp)
+  #_(z/root zp)
+  )
+  


### PR DESCRIPTION
Use Clojure zipper to build a tree structure of the directories and files.

Each `branch` node in the tree represents a `dir` and is a map containing tree keys: `path`, `size`, and `children`.
Each `leaf` node in the tree represents a `file` and is a map containing two keys: `path`, and `size`.

Whilst building the tree a reducer is run over each input line and determines whether to add a new branch or new child node according to the ls output. To calculate the size of each directory we can do a backwards depth first traversal of the tree and for each branch update its size to equal that of the sum of its children.

For part 1 we can then do a forward traversal of the tree to find folders less than or equal to `100000` and sum those.
For part 2 we figure out the missing size, walk the tree to find directories bigger or equal to that size, sort on size, and return the smallest one.

